### PR TITLE
use DEB_CXXFLAGS_MAINT_PREPEND, closes #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,14 +339,14 @@ When building the `stellar-core` packages, it is possible to override the compil
 
 If you need to modify to the c++ compiler flags, you may do so by setting `DEB_CXXFLAGS_SET` in your build environment which overrides the default `CXXFLAGS` value returned to `dpkg-buildpackage` by `dpkg-buildflags`.
 
-One caveat to this which is not immediately obvious, is that we append `-stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi` to the end of `DEB_CXXFLAGS_SET` or by default to the value returned by `dpkg-buildflags`.
-We do this by setting `DEB_CXXFLAGS_MAINT_APPEND` in the `debian/rules` make file to enforce the use of `clang++`,`libc++` and `libc++abi` during compilation.
+One caveat to this which is not immediately obvious, is that we prepend `-stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi` to the beginning of `DEB_CXXFLAGS_SET` or by default to the value returned by `dpkg-buildflags`.
+We do this by setting `DEB_CXXFLAGS_MAINT_PREPEND` in the `debian/rules` make file to enforce the use of `clang++`,`libc++` and `libc++abi` during compilation.
 
 Example:
 
 ```
-DEB_CXXFLAGS_MAINT_APPEND = -stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi
-CXXFLAGS = $(DEB_CXXFLAGS_SET) + $(DEB_CXXFLAGS_MAINT_APPEND)
+DEB_CXXFLAGS_MAINT_PREPEND = -stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi
+CXXFLAGS = $(DEB_CXXFLAGS_MAINT_PREPEND) + $(DEB_CXXFLAGS_SET)
 ```
 
 ##### CFLAGS

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -10,8 +10,8 @@ include /usr/share/dpkg/buildflags.mk
 # see FEATURE AREAS in dpkg-buildflags(1)
 #export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
-# package maintainers to append CXXFLAGS
-export DEB_CXXFLAGS_MAINT_APPEND  = -stdlib=libc++ -fno-omit-frame-pointer -O3 -ggdb -isystem /usr/include/libcxxabi
+# package maintainers to prepend CXXFLAGS
+export DEB_CXXFLAGS_MAINT_PREPEND  = -stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi
 
 # set DEB_CONFIGURE_OPTS in your environment to override
 DEB_CONFIGURE_OPTS ?= --prefix=/usr --includedir=/usr/include --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc --localstatedir=/var


### PR DESCRIPTION
 * removed compiler optimization flag, rely on `dpkg-buildflags` defaults
 * removed GDB debugging information, rely on `dpkg-buildflags` defaults
 * update documentation

@MonsieurNicolas If we decide to support overrides of the compiler used during build time, we would need to allow overriding of the `CXX` environment variable using a "Set if not defined" operator (`?=`) and add `g++`/`libstdc++`  dependencies to the "Build-Depends" in `debian/control`.