### PR TITLE
Use history.stellar.org endpoint

### DIFF
--- a/stellar-core-postgres/stellar-core_postgres.cfg
+++ b/stellar-core-postgres/stellar-core_postgres.cfg
@@ -7,7 +7,8 @@ NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 KNOWN_PEERS=[
 "core-testnet1.stellar.org",
 "core-testnet2.stellar.org",
-"core-testnet3.stellar.org"]
+"core-testnet3.stellar.org"
+]
 
 LOG_FILE_PATH="/var/log/stellar/stellar-core.log"
 BUCKET_DIR_PATH="/var/lib/stellar/buckets"
@@ -26,15 +27,16 @@ THRESHOLD_PERCENT=51 # rounded up -> 2 nodes out of 3
 VALIDATORS=[
 "GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y  sdf1",
 "GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP  sdf2",
-"GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z  sdf3"]
+"GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z  sdf3"
+]
 
 
 #The history store of the Stellar testnet
 [HISTORY.h1]
-get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
 
 [HISTORY.h2]
-get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
 
 [HISTORY.h3]
-get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
+get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"


### PR DESCRIPTION
 * uses CDN cached history.stellar.org
 * stops accessing S3 bucket directly