### PR TITLE
prometheus-exporter: Add histogram support. Closed #57

### DIFF
--- a/stellar-core-prometheus-exporter/stellar-core-prometheus-exporter.py
+++ b/stellar-core-prometheus-exporter/stellar-core-prometheus-exporter.py
@@ -177,10 +177,10 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
         try:
             response = requests.get(args.info_uri)
         except requests.ConnectionError:
-            self.error(504, 'Error retrieving data from {}'.format(info.uri))
+            self.error(504, 'Error retrieving data from {}'.format(args.info_uri))
             return
         if not response.ok:
-            self.error(504, 'Error retrieving data from {}'.format(info.uri))
+            self.error(504, 'Error retrieving data from {}'.format(args.info_uri))
             return
         try:
             info = response.json()['info']


### PR DESCRIPTION
One thing to note is that due to the way metrics are named we end up with duplicated "count" in some metric names:
```
stellar_core_ledger_transaction_count_sum
stellar_core_ledger_transaction_count_count

stellar_core_ledger_operation_count_sum
stellar_core_ledger_operation_count_count

stellar_core_ledger_transaction_count_sum
stellar_core_ledger_transaction_count_count
```

I think that's absolutely fine because if we remove it we end up with things like "stellar_core_ledger_transaction_sum" which makes no sense