### PR TITLE
prometheus-exporter: expose quorum critical peers as labels

### DIFF
--- a/stellar-core-prometheus-exporter/stellar-core-prometheus-exporter.py
+++ b/stellar-core-prometheus-exporter/stellar-core-prometheus-exporter.py
@@ -255,11 +255,15 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
             if 'critical' in info['quorum']['transitive']:
                 g = Gauge('stellar_core_quorum_transitive_critical',
                           'Stellar core quorum transitive critical',
-                          self.label_names, registry=self.registry)
+                          self.label_names + ['peer'], registry=self.registry)
                 if info['quorum']['transitive']['critical']:
-                    g.labels(*self.labels).set(1)
+                    for peer_list in info['quorum']['transitive']['critical']:
+                        for peer in peer_list:  # critical peers are in a nested group
+                            l = self.labels + [peer]
+                            g.labels(*l).set(1)
                 else:
-                    g.labels(*self.labels).set(0)
+                    l = self.labels + ['']  # peer label set to empty string
+                    g.labels(*l).set(0)
 
         # Peers metrics
         g = Gauge('stellar_core_peers_authenticated_count',


### PR DESCRIPTION
When there are no critical peers expose data like this:
```
stellar_core_quorum_transitive_critical{peer=""} 0
```
And when critical nodes are found each of them is exposed as individual timeseries, for example:
```
stellar_core_quorum_transitive_critical{peer="mypeer_1"} 1
stellar_core_quorum_transitive_critical{peer="mypeer_2"} 1
stellar_core_quorum_transitive_critical{peer="mypeer_3"} 1
```