### PR TITLE
stellar-core exporter: Improve quorum transitive critical metric

### DIFF
--- a/stellar-core-prometheus-exporter/stellar-core-prometheus-exporter.py
+++ b/stellar-core-prometheus-exporter/stellar-core-prometheus-exporter.py
@@ -257,14 +257,14 @@ class StellarCoreHandler(BaseHTTPRequestHandler):
             if 'critical' in info['quorum']['transitive']:
                 g = Gauge('stellar_core_quorum_transitive_critical',
                           'Stellar core quorum transitive critical',
-                          self.label_names + ['peer'], registry=self.registry)
+                          self.label_names + ['critical_validators'], registry=self.registry)
                 if info['quorum']['transitive']['critical']:
                     for peer_list in info['quorum']['transitive']['critical']:
-                        for peer in peer_list:  # critical peers are in a nested group
-                            l = self.labels + [peer]
-                            g.labels(*l).set(1)
+                        critical_peers = ','.join(sorted(peer_list))  # label value is comma separated listof peers
+                        l = self.labels + [critical_peers]
+                        g.labels(*l).set(1)
                 else:
-                    l = self.labels + ['']  # peer label set to empty string
+                    l = self.labels + ['']  # critical_validators label set to empty string
                     g.labels(*l).set(0)
 
         # Peers metrics


### PR DESCRIPTION
Quorum transtive critical peers are reported as list of lists.  They will
normally be reported in groups so there is no need to expose each peer
individually. Instead we'll sort and concatenate each group and report
as one timeseries.