### PR TITLE
upgrade stellar-core to clang8

### DIFF
--- a/stellar-core/debian/changelog
+++ b/stellar-core/debian/changelog
@@ -1,6 +1,6 @@
 stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
 
-  * use clang-5.0 and llvm's libc++
+  * use clang-8 and llvm's libc++
 
   * added libc++-dev libc++abi-dev Build-Depends
 

--- a/stellar-core/debian/control
+++ b/stellar-core/debian/control
@@ -2,13 +2,13 @@ Source: stellar-core
 Section: web
 Priority: optional
 Maintainer: Package Maintainer <packages@stellar.org>
-Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-5.0 (>=5.0), libc++-dev, libc++abi-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common
+Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-8 (>=8), libc++-8-dev, libc++abi-8-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common
 Standards-Version: 3.9.6
 Homepage: https://www.stellar.org
 
 Package: stellar-core
 Architecture: any
-Depends: libc++1, libc++abi1, libpq5, libsqlite3-0 (>=3.11.0), stellar-core-utils
+Depends: libc++1-8, libc++abi1-8, libpq5, libsqlite3-0 (>=3.11.0), stellar-core-utils
 Recommends: stellar-core-utils, stellar-core-prometheus-exporter
 Description: Stellar  is  a  decentralized, federated peer-to-peer network
  Stellar  is  a  decentralized, federated peer-to-peer network that allows people to send payments in any asset anywhere in the world instantaneously, and with minimal fee.

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -25,7 +25,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS)
+	CC=clang-8 CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -25,7 +25,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	CXX=clang++-5.0 ./configure $(DEB_CONFIGURE_OPTS)
+	CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade


### PR DESCRIPTION
- Upgrade from clang 5 to clang 8. This change allows us to use the `--enable-tracy` flag. 
- cd7941f3142ce8ac3d6368493e24bc5c2f404500 fixes #117.