### PR TITLE
Update history for validators

### DIFF
--- a/docs/examples/pubnet-validator-full/stellar-core.cfg
+++ b/docs/examples/pubnet-validator-full/stellar-core.cfg
@@ -68,21 +68,21 @@ NAME="sdf_1"
 HOME_DOMAIN="www.stellar.org"
 PUBLIC_KEY="GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH"
 ADDRESS="core-live-a.stellar.org"
-HISTORY="aws s3 cp --region eu-west-1 s3://history.stellar.org/prd/core-live/core_live_001/{0} {1}"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
 
 [[VALIDATORS]]
 NAME="sdf_2"
 HOME_DOMAIN="www.stellar.org"
 PUBLIC_KEY="GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK"
 ADDRESS="core-live-b.stellar.org"
-HISTORY="aws s3 cp --region eu-west-1 s3://history.stellar.org/prd/core-live/core_live_002/{0} {1}"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
 
 [[VALIDATORS]]
 NAME="sdf_3"
 HOME_DOMAIN="www.stellar.org"
 PUBLIC_KEY="GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ"
 ADDRESS="core-live-c.stellar.org"
-HISTORY="aws s3 cp --region eu-west-1 s3://history.stellar.org/prd/core-live/core_live_003/{0} {1}"
+HISTORY="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"
 
 [[VALIDATORS]]
 NAME="SatoshiPay_SG_Singapore"


### PR DESCRIPTION
This updates the history values to use curl on the endpoint instead of attempting an S3 get via the aws cli.