### PR TITLE
stellar-core: simplify logic and disable tests

### DIFF
--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -16,7 +16,7 @@ export DEB_CXXFLAGS_MAINT_PREPEND  = -stdlib=libc++ -fno-omit-frame-pointer -isy
 # set DEB_CONFIGURE_OPTS in your environment to override
 DEB_CONFIGURE_OPTS ?= --prefix=/usr --includedir=/usr/include --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc --localstatedir=/var
 
-# set EXTRA_DEB_CONFIGURE_OPTS in your environment to append options
+# set DEB_CONFIGURE_OPTS_APPEND in your environment to append options
 
 %:
 	dh $@ --with autoreconf --with systemd --parallel
@@ -27,7 +27,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	CC=clang-8 CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS) $(EXTRA_DEB_CONFIGURE_OPTS)
+	CC=clang-8 CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS) $(DEB_CONFIGURE_OPTS_APPEND)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -13,6 +13,9 @@ include /usr/share/dpkg/buildflags.mk
 # package maintainers to prepend CXXFLAGS
 export DEB_CXXFLAGS_MAINT_PREPEND  = -stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi
 
+# set DEB_CONFIGURE_OPTS in your environment to override
+DEB_CONFIGURE_OPTS ?= --prefix=/usr --includedir=/usr/include --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc --localstatedir=/var
+
 # set EXTRA_DEB_CONFIGURE_OPTS in your environment to append options
 
 %:
@@ -24,7 +27,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	CC=clang-8 CXX=clang++-8 ./configure --prefix=/usr --includedir=/usr/include --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc --localstatedir=/var $(EXTRA_DEB_CONFIGURE_OPTS)
+	CC=clang-8 CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS) $(EXTRA_DEB_CONFIGURE_OPTS)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -13,11 +13,10 @@ include /usr/share/dpkg/buildflags.mk
 # package maintainers to prepend CXXFLAGS
 export DEB_CXXFLAGS_MAINT_PREPEND  = -stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi
 
-# set DEB_CONFIGURE_OPTS in your environment to override
-DEB_CONFIGURE_OPTS ?= --prefix=/usr --includedir=/usr/include --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc --localstatedir=/var
+# set EXTRA_DEB_CONFIGURE_OPTS in your environment to append options
 
 %:
-	dh $@ --with autoreconf --with systemd
+	dh $@ --with autoreconf --with systemd --parallel
 override_dh_autoreconf:
 	./autogen.sh --skip-submodules # This skips the autogen.sh `git submodule update --init`
 
@@ -25,7 +24,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	CC=clang-8 CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS)
+	CC=clang-8 CXX=clang++-8 ./configure --prefix=/usr --includedir=/usr/include --mandir=/usr/share/man --infodir=/usr/share/info --sysconfdir=/etc --localstatedir=/var $(EXTRA_DEB_CONFIGURE_OPTS)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
@@ -35,3 +34,6 @@ override_dh_auto_install:
 
 override_dh_strip:
 	dh_strip --dbg-package=stellar-core-dbg
+
+# Disable tests at build time
+override_dh_auto_test:


### PR DESCRIPTION
* disable tests during builds
* add optional DEB_CONFIGURE_OPTS_APPEND  variable support
* enable parallel builds