### PR TITLE
Use more generic format for postgres dependencies

### DIFF
--- a/stellar-core-postgres/debian/control
+++ b/stellar-core-postgres/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.stellar.org/
 
 Package: stellar-core-postgres
 Architecture: any
-Depends: stellar-core, postgresql-9.5 (>=9.5.2) | postgresql-10
+Depends: stellar-core, postgresql (>=9.5)
 Description: This package will configure PostgreSQL for stellar-core locally.
  * creates/manages stellar user
  * creates stellar PostgreSQL role

--- a/stellar-horizon-postgres/debian/control
+++ b/stellar-horizon-postgres/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.stellar.org/
 
 Package: stellar-horizon-postgres
 Architecture: any
-Depends: stellar-horizon, postgresql-9.5 (>=9.5.2) | postgresql-10
+Depends: stellar-horizon, postgresql (>=9.5)
 Description: This package will configure PostgreSQL for stellar-horizon locally.
  * creates/manages stellar user
  * creates stellar PostgreSQL role


### PR DESCRIPTION
This change makes postgres dependency forwards compatible