### PR TITLE
Update stellar-captive-core config files

### DIFF
--- a/stellar-captive-core/debian/stellar-captive-core.defaults
+++ b/stellar-captive-core/debian/stellar-captive-core.defaults
@@ -6,7 +6,7 @@ STELLAR_CORE_URL="http://127.0.0.1:11626"
 # Captive Core Ingestion Config
 ENABLE_CAPTIVE_CORE_INGESTION=true
 STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core
-STELLAR_CORE_CONFIG_PATH=/etc/stellar/stellar-core.cfg
+CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/stellar/stellar-core.cfg
 # end Captive Core
 
 PORT=8000

--- a/stellar-captive-core/debian/stellar-captive-core.defaults
+++ b/stellar-captive-core/debian/stellar-captive-core.defaults
@@ -1,7 +1,6 @@
 ## /etc/default/stellar-horizon
 NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 DATABASE_URL="dbname=horizon user=stellar host=/var/run/postgresql"
-STELLAR_CORE_DATABASE_URL="dbname=stellar user=stellar host=/var/run/postgresql"
 STELLAR_CORE_URL="http://127.0.0.1:11626"
 
 # Captive Core Ingestion Config
@@ -10,10 +9,7 @@ STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core
 STELLAR_CORE_CONFIG_PATH=/etc/stellar/stellar-core.cfg
 # end Captive Core
 
-FRIENDBOT_SECRET=
 PORT=8000
-SENTRY_DSN=
-LOGGLY_TOKEN=
 PER_HOUR_RATE_LIMIT=9000
 INGEST=true
 HISTORY_ARCHIVE_URLS="https://history.stellar.org/prd/core-testnet/core_testnet_001"

--- a/stellar-captive-core/stellar-core_captive-pubnet.cfg
+++ b/stellar-captive-core/stellar-core_captive-pubnet.cfg
@@ -1,19 +1,5 @@
-# This is a sample configuration from the stellar-captive-core package
-HTTP_PORT=11626
-PUBLIC_HTTP_PORT=false
-
-NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
-
-LOG_FILE_PATH="/var/log/stellar/stellar-core.log"
-BUCKET_DIR_PATH="/var/lib/stellar/buckets"
-
-DATABASE="postgresql://dbname=stellar user=stellar"
-
-CATCHUP_COMPLETE=false
-CATCHUP_RECENT=1024
-
-UNSAFE_QUORUM=true
-FAILURE_SAFETY=1
+# This is a sample configuration from the stellar-captive-core package.
+# Please note that only HOME_DOMAINS and VALIDATORS tables are required.
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN="www.stellar.org"

--- a/stellar-captive-core/stellar-core_captive-testnet.cfg
+++ b/stellar-captive-core/stellar-core_captive-testnet.cfg
@@ -1,19 +1,5 @@
-# This is a sample configuration from the stellar-captive-core package
-HTTP_PORT=11626
-PUBLIC_HTTP_PORT=false
-
-NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
-
-LOG_FILE_PATH="/var/log/stellar/stellar-core.log"
-BUCKET_DIR_PATH="/var/lib/stellar/buckets"
-
-DATABASE="postgresql://dbname=stellar user=stellar"
-
-CATCHUP_COMPLETE=false
-CATCHUP_RECENT=1024
-
-UNSAFE_QUORUM=true
-FAILURE_SAFETY=1
+# This is a sample configuration from the stellar-captive-core package.
+# Please note that only HOME_DOMAINS and VALIDATORS tables are required.
 
 [[HOME_DOMAINS]]
 HOME_DOMAIN="testnet.stellar.org"


### PR DESCRIPTION
This commit updates config files in `stellar-captive-core` package. Starting from https://github.com/stellar/go/pull/3262 config file for stellar-core is generated by Horizon (except quorum slices that need to be explicitly set by the admin).