### PR TITLE
stellar-horizon: disable dh_strip

### DIFF
--- a/stellar-horizon/debian/rules
+++ b/stellar-horizon/debian/rules
@@ -20,6 +20,11 @@
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade
 
+# Disable dh_strip to ship unmodified binary in the package.
+# This allows anyone to "go build" exactly the same binary
+# we ship with the package (reproducible builds)
+override_dh_strip:
+
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 #override_dh_auto_configure:


### PR DESCRIPTION
This change ensures we ship unmodifed binary in the package.
It will let anyone "go build" from source and confirm resulting
binary matches what we ship in the package.