### PR TITLE
Update default Captive Core Horizon configuration

### DIFF
--- a/stellar-captive-core/debian/stellar-captive-core.default
+++ b/stellar-captive-core/debian/stellar-captive-core.default
@@ -6,8 +6,8 @@ STELLAR_CORE_URL="http://127.0.0.1:11626"
 # Captive Core Ingestion Config
 ENABLE_CAPTIVE_CORE_INGESTION=true
 STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core
-CAPTIVE_CORE_CONFIG_APPEND_PATH=/etc/stellar/stellar-core.cfg
-TMPDIR=/var/lib/stellar
+CAPTIVE_CORE_CONFIG_PATH=/etc/stellar/stellar-core_captive-testnet.cfg
+CAPTIVE_CORE_STORAGE_PATH=/var/lib/stellar
 # end Captive Core
 
 PORT=8000


### PR DESCRIPTION
 - As of v2.1, we don't need the `TMPDIR` workaround and should prefer setting `--captive-core-storage-path`.
 - We also do more validation on the input TOML for `--captive-core-config-path`, and we should point it to an actual Captive Core config rather than the full Stellar Core config