### PR TITLE
Add Build-Depends for tracy support tools to stellar-core

### DIFF
--- a/stellar-core/debian/changelog
+++ b/stellar-core/debian/changelog
@@ -1,5 +1,9 @@
 stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
 
+  * added libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev Build-Depends
+
+stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
+
   * use clang-8 and llvm's libc++
 
   * added libc++-dev libc++abi-dev Build-Depends

--- a/stellar-core/debian/control
+++ b/stellar-core/debian/control
@@ -2,7 +2,7 @@ Source: stellar-core
 Section: web
 Priority: optional
 Maintainer: Package Maintainer <packages@stellar.org>
-Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-8 (>=8), libc++-8-dev, libc++abi-8-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common
+Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-8 (>=8), libc++-8-dev, libc++abi-8-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common, libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev
 Standards-Version: 3.9.6
 Homepage: https://www.stellar.org
 


### PR DESCRIPTION
This is a followup to https://github.com/stellar/pipelines/pull/244 to enable building and packaging tracy tools in the perftest package (will not add anything to the main non-perftest package).