### PR TITLE
stellar-core: format changelog

### DIFF
--- a/stellar-core/debian/changelog
+++ b/stellar-core/debian/changelog
@@ -1,12 +1,16 @@
 stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
 
-  * added libtbb-dev Build-Depends
+  * New release
 
-stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
+ -- Package Maintainer <packages@stellar.org>  Mon, 6 Sep 2021 09:38:00 +0000
 
-  * added libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev Build-Depends
+stellar-core (17.4.1-700) stable; urgency=medium
 
-stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
+  * added libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev libtbb-dev Build-Depends
+
+ -- Package Maintainer <packages@stellar.org>  Sat, 4 Sep 2021 02:29:00 +0000
+
+stellar-core (14.0.0-37) stable; urgency=medium
 
   * use clang-8 and llvm's libc++
 
@@ -16,7 +20,7 @@ stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
 
   * clean up dependencies
 
- -- Package Maintainer <packages@stellar.org>  Sat, 23 Nov 2018 23:03:50 +0000
+ -- Package Maintainer <packages@stellar.org>  Wed, 5 Aug 2020 22:35:15 +0000
 
 stellar-core (9.2.0-9) stable; urgency=medium
 


### PR DESCRIPTION
This change adds timestamps and version numbers to the changelog entries.
It also combines two dependency additions into one entry for brevity
since we won't be releasing package with just partial depency change.