### PR TITLE
stellar-core: remove templated changelog entry

### DIFF
--- a/stellar-core/debian/changelog
+++ b/stellar-core/debian/changelog
@@ -1,9 +1,3 @@
-stellar-core (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
-
-  * New release
-
- -- Package Maintainer <packages@stellar.org>  Mon, 6 Sep 2021 09:38:00 +0000
-
 stellar-core (17.4.1-700) stable; urgency=medium
 
   * added libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev libtbb-dev Build-Depends


### PR DESCRIPTION
This change will let us use debian's `dch` tool to edit the changelog
programmatically which will ensure consistency and correct timestamps.