### PR TITLE
build with clang-10

### DIFF
--- a/stellar-core/debian/changelog
+++ b/stellar-core/debian/changelog
@@ -1,3 +1,9 @@
+stellar-core (19.2.0) stable; urgency=medium
+
+  * build with clang-10
+
+ -- Package Maintainer <packages@stellar.org>  Mon, 6 Jun 2022 01:05:00 +0000
+
 stellar-core (19.0.0) stable; urgency=medium
 
   * added cargo rustc Build-Depends

--- a/stellar-core/debian/control
+++ b/stellar-core/debian/control
@@ -2,7 +2,7 @@ Source: stellar-core
 Section: web
 Priority: optional
 Maintainer: Package Maintainer <packages@stellar.org>
-Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-8 (>=8), libc++-8-dev, libc++abi-8-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common, libcapstone-dev, libfreetype6-dev, libglfw3-dev, libgtk2.0-dev, libtbb-dev, cargo (>=0.58.0), rustc (>=1.57.0)
+Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-10 (>=10), libc++-10-dev, libc++abi-10-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common, libcapstone-dev, libfreetype6-dev, libglfw3-dev, libgtk2.0-dev, libtbb-dev, cargo (>=0.58.0), rustc (>=1.57.0)
 Standards-Version: 3.9.6
 Homepage: https://www.stellar.org
 

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -27,7 +27,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	CC=clang-8 CXX=clang++-8 ./configure $(DEB_CONFIGURE_OPTS) $(DEB_CONFIGURE_OPTS_APPEND)
+	CC=clang-10 CXX=clang++-10 ./configure $(DEB_CONFIGURE_OPTS) $(DEB_CONFIGURE_OPTS_APPEND)
 
 override_dh_systemd_start:
 	dh_systemd_start --restart-after-upgrade


### PR DESCRIPTION
bionic has clang-10 and this allows us to build with the same compiler that we use in Github actions