### PR TITLE
Add --recursive-modules flag to git X-Files

### DIFF
--- a/stellar-core/debian/patches/removeGitDependency.diff
+++ b/stellar-core/debian/patches/removeGitDependency.diff
@@ -15,7 +15,7 @@
   echo "$message"
 - echo "SRC_H_FILES" = $(git ls-files '*.h' '*.[ih]pp' | tr " " "\n" | sort | uniq | egrep -v '(test|simulation)/' | tr "\n" " ")
 - echo "SRC_CXX_FILES" = $(git ls-files '*.cpp' | tr " " "\n" | sort | uniq |  egrep -v '(test|simulation)/' | tr "\n" " ")
-- echo "SRC_X_FILES" = $(git ls-files '*.x' | tr " " "\n" | sort | uniq | tr "\n" " ")
+- echo "SRC_X_FILES" = $(git ls-files --recurse-submodules '*.x' | tr " " "\n" | sort | uniq | tr "\n" " ")
 - echo "SRC_TEST_H_FILES" = $(git ls-files '*.h' '*.[ih]pp' | tr " " "\n" | egrep '(test|simulation)/' | tr "\n" " ")
 - echo "SRC_TEST_CXX_FILES" = $(git ls-files '*.cpp' | tr " " "\n" | sort | uniq |  egrep '(test|simulation)/' | tr "\n" " ")
 - echo "SRC_RUST_FILES" = $(git ls-files '*.rs' | tr " " "\n" | sort | uniq | tr "\n" " ")


### PR DESCRIPTION
A `--recursive-modules` flag was added to the `stellar-core/mk` via [this](https://github.com/stellar/stellar-core/commit/a32ac9773868c2a1fb3364e095701f93f55c9f06#diff-38ada6707926bc9968f69956c4a0fb3aea560af93f1ac96784a4f42a1ff0b181R23). We need to update the patch here in packages repository too. This PR will add the flag.



Signed-off-by: Satyam Zode <satyamz@users.noreply.github.com>