### PR TITLE
Fix stellar horizon db migrate error handling

### DIFF
--- a/stellar-horizon/debian/stellar-horizon.postinst
+++ b/stellar-horizon/debian/stellar-horizon.postinst
@@ -41,7 +41,8 @@ case "$1" in
           # check `horizon` database has been initialised
           if echo "SELECT 'horizon' FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'history_ledgers';" | runuser -l ${ROLE} -c "psql '${db_connection_string}' -tA" 2>&1 | grep 'horizon' > /dev/null; then
             export DATABASE_URL="$db_connection_string"
-            sudo -E -u ${ROLE} stellar-horizon db migrate up && echo 'info: migrated database'
+            sudo -E -u ${ROLE} stellar-horizon db migrate up
+            echo 'info: migrated database'
           else
             echo "warning: the horizon database is not yet initialised, try running 'stellar-horizon-cmd db init'"
             echo "warning: migrations have not been run; won't attempt to start horizon"


### PR DESCRIPTION
`stellar-horizon db migrate up` command failures were unknown because of `set -e` and `&&` operation. This will move message to next line, and fail before the message is printed if there any failure in the db migrate up command.

Signed-off-by: Satyam Zode <satyamz@users.noreply.github.com>