### PR TITLE
Install rust using install-rust.sh before building stellar-core

### DIFF
--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -18,6 +18,10 @@ DEB_CONFIGURE_OPTS ?= --prefix=/usr --includedir=/usr/include --mandir=/usr/shar
 
 # set DEB_CONFIGURE_OPTS_APPEND in your environment to append options
 
+# add the directory rust is installed into to PATH
+PATH := $(HOME)/.cargo/bin:$(PATH)
+export PATH
+
 %:
 	dh $@ --with autoreconf --with systemd --parallel
 override_dh_autoreconf:
@@ -27,6 +31,7 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
+	./install-rust.sh
 	CC=clang-10 CXX=clang++-10 ./configure $(DEB_CONFIGURE_OPTS) $(DEB_CONFIGURE_OPTS_APPEND)
 
 override_dh_systemd_start:


### PR DESCRIPTION
This combined with https://github.com/stellar/stellar-core/pull/3527 should address https://github.com/stellar/packages/issues/168 .. this should not land until the core change lands.