### PR TITLE
Try using CURDIR and an explicit set of PATH entries

### DIFF
--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -19,7 +19,8 @@ DEB_CONFIGURE_OPTS ?= --prefix=/usr --includedir=/usr/include --mandir=/usr/shar
 # set DEB_CONFIGURE_OPTS_APPEND in your environment to append options
 
 # add the directory rust is installed into to PATH
-PATH := rusthome/.cargo/bin:$(PATH)
+RUSTHOME = $(CURDIR)/rusthome
+PATH := $(RUSTHOME)/.cargo/bin:/usr/sbin:/usr/bin:/sbin:/bin
 export PATH
 
 %:
@@ -31,8 +32,8 @@ override_dh_autoreconf:
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 override_dh_auto_configure:
-	mkdir rusthome
-	HOME=rusthome ./install-rust.sh
+	mkdir -p $(RUSTHOME)
+	HOME=$(RUSTHOME) ./install-rust.sh
 	CC=clang-10 CXX=clang++-10 ./configure $(DEB_CONFIGURE_OPTS) $(DEB_CONFIGURE_OPTS_APPEND)
 
 override_dh_systemd_start:


### PR DESCRIPTION
more attempts at making the rust install not break configure