### PR TITLE
stellar-horizon: export INGEST environment variable inthe postinst script

### DIFF
--- a/stellar-horizon/debian/stellar-horizon.postinst
+++ b/stellar-horizon/debian/stellar-horizon.postinst
@@ -36,11 +36,15 @@ case "$1" in
       if [ -f /etc/default/stellar-horizon ]; then
         # extract --db_url from /etc/default/stellar-horizon
         db_connection_string=$(grep -r '^DATABASE_URL' /etc/default/stellar-horizon | sed 's/DATABASE_URL=//g' | sed 's/"//g');
+        # extract INGEST flag from /etc/default/stellar-horizon. Default
+        ingest_flag=$(grep -r '^INGEST' /etc/default/stellar-horizon||echo "INGEST=true");
+        ingest_flag=$(echo $INGEST | sed 's/INGEST=//g' | sed 's/"//g');
         # check `stellar` role and DATABASE_URL
         if echo "SELECT 'role_exists' FROM pg_roles WHERE rolname='${ROLE}'" | runuser -l ${ROLE} -c "psql '${db_connection_string}' -tA" 2>&1 | grep 'role_exists' > /dev/null; then
           # check `horizon` database has been initialised
           if echo "SELECT 'horizon' FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'history_ledgers';" | runuser -l ${ROLE} -c "psql '${db_connection_string}' -tA" 2>&1 | grep 'horizon' > /dev/null; then
             export DATABASE_URL="$db_connection_string"
+            export INGEST="$ingest_flag"
             sudo -E -u ${ROLE} stellar-horizon db migrate up
             echo 'info: migrated database'
           else


### PR DESCRIPTION
### What

Ensure we export INGEST environment variable inthe postinst script

### Why

This will allow horizon to skip migrations on non-ingesting nodes