### PR TITLE
stellar-horizon: further ingest flag support improvements

### DIFF
--- a/stellar-horizon/debian/stellar-horizon.postinst
+++ b/stellar-horizon/debian/stellar-horizon.postinst
@@ -37,7 +37,7 @@ case "$1" in
         # extract --db_url from /etc/default/stellar-horizon
         db_connection_string=$(grep -r '^DATABASE_URL' /etc/default/stellar-horizon | sed 's/DATABASE_URL=//g' | sed 's/"//g');
         # extract INGEST flag from /etc/default/stellar-horizon. Default
-        ingest_flag=$(grep -r '^INGEST' /etc/default/stellar-horizon||echo "INGEST=true");
+        ingest_flag=$(grep -r '^INGEST=' /etc/default/stellar-horizon||echo "INGEST=true");
         ingest_flag=$(echo $ingest_flag | sed 's/INGEST=//g' | sed 's/"//g');
         # check `stellar` role and DATABASE_URL
         if echo "SELECT 'role_exists' FROM pg_roles WHERE rolname='${ROLE}'" | runuser -l ${ROLE} -c "psql '${db_connection_string}' -tA" 2>&1 | grep 'role_exists' > /dev/null; then


### PR DESCRIPTION
### What

Ensure we only pick up INGEST flag and not other flags starting with INGEST

### Why

There are some horizon settings that begin with INGEST_ and the script was picking those up