### PR TITLE
Update stellar-core dependencies for Ubuntu 22.04

### DIFF
--- a/stellar-core/debian/changelog
+++ b/stellar-core/debian/changelog
@@ -1,3 +1,7 @@
+stellar-core (19.7.1) stable; urgency=medium
+
+  * build with clang-12
+
 stellar-core (19.1.0) stable; urgency=medium
 
   * build with clang-10

--- a/stellar-core/debian/control
+++ b/stellar-core/debian/control
@@ -2,7 +2,7 @@ Source: stellar-core
 Section: web
 Priority: optional
 Maintainer: Package Maintainer <packages@stellar.org>
-Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-10 (>=10), libc++-10-dev, libc++abi-10-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), dh-systemd (>=1.5), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common, libcapstone-dev, libfreetype6-dev, libglfw3-dev, libgtk2.0-dev, libtbb-dev, curl, ca-certificates
+Build-Depends: debhelper (>=9), autoconf (>=2.69), automake (>=1.15), binutils (>=2.26), bison (>=3.0.4), build-essential (>=12.1), clang-12 (>=12), libc++-12-dev, libc++abi-12-dev, devscripts (>=2.16.2), dh-autoreconf (>=11), flex (>=2.6.0), git (>=2.7.4), libpq-dev (>=9.5.2), libtool (>=2.4.6), pandoc (>=1.16.0.2~dfsg-1), pkg-config (>=0.29.1), libsqlite3-0 (>=3.11.0), postgresql-common, libcapstone-dev, libfreetype6-dev, libglfw3-dev, libgtk2.0-dev, libtbb-dev, curl, ca-certificates, llvm-12 (>=12.0.0), llvm-12-dev (>=12.0.0), parallel, libunwind-dev
 Standards-Version: 3.9.6
 Homepage: https://www.stellar.org
 

--- a/stellar-core/debian/rules
+++ b/stellar-core/debian/rules
@@ -23,8 +23,8 @@ export HOME := $(CURDIR)/rusthome
 export PATH := $(HOME)/.cargo/bin:$(PATH)
 
 # export CC and CXX so they are picked up by the rust cc library
-export CC := clang-10
-export CXX := clang++-10
+export CC := clang-12
+export CXX := clang++-12
 
 %:
 	dh $@ --with autoreconf --with systemd --parallel


### PR DESCRIPTION
### What

Bump stellar-core dependencies to work with ubuntu 20.04 and 22.04. This PR also drops support for Ubuntu 18.04

### Why

We need to build core sore Ubuntu 22.04