### PR TITLE
Update stellar-core-postgres and stellar-core-utils packages for 22.04

### DIFF
--- a/stellar-core-postgres/debian/changelog
+++ b/stellar-core-postgres/debian/changelog
@@ -1,4 +1,4 @@
-stellar-core-postgres (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
+stellar-core-postgres (0.2-9) stable; urgency=medium
 
   * Initial Release.
 

--- a/stellar-core-postgres/debian/control
+++ b/stellar-core-postgres/debian/control
@@ -8,7 +8,7 @@ Homepage: https://www.stellar.org/
 
 Package: stellar-core-postgres
 Architecture: any
-Depends: stellar-core, postgresql (>=9.5)
+Depends: stellar-core, postgresql (>=12)
 Description: This package will configure PostgreSQL for stellar-core locally.
  * creates/manages stellar user
  * creates stellar PostgreSQL role

--- a/stellar-core-utils/debian/changelog
+++ b/stellar-core-utils/debian/changelog
@@ -1,4 +1,4 @@
-stellar-core-utils (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
+stellar-core-utils (0.1-7) stable; urgency=medium
 
   * Initial Release.
 


### PR DESCRIPTION
### What

* update changelog to format that will support updates using dch tool
* bump minimum postgres version to 12

### Why

We need to support Ubuntu 22.04