### PR TITLE
Switch core prometheus exporter to cleaner changelog format

### DIFF
--- a/stellar-core-prometheus-exporter/debian/changelog
+++ b/stellar-core-prometheus-exporter/debian/changelog
@@ -1,4 +1,4 @@
-stellar-core-prometheus-exporter (_VERSION_-_BUILD_VERSION_) stable; urgency=medium
+stellar-core-prometheus-exporter (0.10.5-17) stable; urgency=medium
 
   * Initial Release.
 


### PR DESCRIPTION
### What

Switch core prometheus exporter to cleaner changelog format.

### Why

We will use dch command to update changelog in a simpler way