### PR TITLE
Make soroban-rpc depend on stellar-core specific version

### DIFF
--- a/stellar-soroban-rpc/debian/control
+++ b/stellar-soroban-rpc/debian/control
@@ -8,6 +8,6 @@ Homepage: https://www.stellar.org/
 
 Package: stellar-soroban-rpc
 Architecture: any
-Depends: stellar-core
+Depends: stellar-core (= _CORE_VERSION_)
 Description: Soroban RPC is the client facing API server for the Stellar Soraban Smart Contracts ecosystem. It acts as the interface between stellar-core and applications that want to access smart contracts on the Stellar network.
  

--- a/stellar-soroban-rpc/debian/control
+++ b/stellar-soroban-rpc/debian/control
@@ -8,5 +8,6 @@ Homepage: https://www.stellar.org/
 
 Package: stellar-soroban-rpc
 Architecture: any
+Depends: stellar-core
 Description: Soroban RPC is the client facing API server for the Stellar Soraban Smart Contracts ecosystem. It acts as the interface between stellar-core and applications that want to access smart contracts on the Stellar network.
  

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.default
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.default
@@ -4,7 +4,7 @@
 ENDPOINT=localhost:8003
 FRIENDBOT_URL=https://friendbot-futurenet.stellar.org/
 NETWORK_PASSPHRASE="Test SDF Future Network ; October 2022"
-CAPTIVE_CORE_CONFIG_PATH=/etc/stellar/soroban-rpc/etc/stellar-captive-core.cfg
+CAPTIVE_CORE_CONFIG_PATH=/etc/stellar/soroban-rpc/stellar-captive-core.cfg
 CAPTIVE_CORE_STORAGE_PATH=/var/lib/stellar/soroban-rpc/captive-core
 CAPTIVE_CORE_USE_DB=true
 STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.default
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.default
@@ -2,11 +2,15 @@
 
 # define the port on local machine that soroban rpc server will bind to.
 ENDPOINT=localhost:8003
-# for now rpc requires access to horizon, this will change.
-HORIZON_URL=http://localhost:8000
+FRIENDBOT_URL=https://friendbot-futurenet.stellar.org/
 NETWORK_PASSPHRASE="Test SDF Future Network ; October 2022"
-# for now rpc requires access to core, this will change.
-STELLAR_CORE_URL="http://localhost:11626"
+CAPTIVE_CORE_CONFIG_PATH=/etc/stellar/soroban-rpc/etc/stellar-captive-core.cfg
+CAPTIVE_CORE_STORAGE_PATH=/var/lib/stellar/soroban-rpc/captive-core
+CAPTIVE_CORE_USE_DB=true
+STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core
+HISTORY_ARCHIVE_URLS="http://history-futurenet.stellar.org"
+DB_PATH="/var/lib/stellar/soroban-rpc/soroban_rpc.sqlite"
+STELLAR_CAPTIVE_CORE_HTTP_PORT=0
 
 # minimum log severity (debug, info, warn, error), default=info 
 # LOG_LEVEL=info

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.default
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.default
@@ -8,7 +8,7 @@ CAPTIVE_CORE_CONFIG_PATH=/etc/stellar/soroban-rpc/etc/stellar-captive-core.cfg
 CAPTIVE_CORE_STORAGE_PATH=/var/lib/stellar/soroban-rpc/captive-core
 CAPTIVE_CORE_USE_DB=true
 STELLAR_CORE_BINARY_PATH=/usr/bin/stellar-core
-HISTORY_ARCHIVE_URLS="http://history-futurenet.stellar.org"
+HISTORY_ARCHIVE_URLS="https://history-futurenet.stellar.org"
 DB_PATH="/var/lib/stellar/soroban-rpc/soroban_rpc.sqlite"
 STELLAR_CAPTIVE_CORE_HTTP_PORT=0
 

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.dirs
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.dirs
@@ -1,2 +1,3 @@
 /var/lib/stellar/
+/var/lib/stellar/soroban-rpc/captive-core/
 /var/log/stellar/

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.install
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.install
@@ -1,1 +1,2 @@
 stellar-soroban-rpc usr/bin/
+stellar-core_captive-futurenet.cfg etc/stellar

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.links
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.links
@@ -1,2 +1,1 @@
 /etc/stellar/stellar-core_captive-futurenet.cfg /etc/stellar/soroban-rpc/etc/stellar-captive-core.cfg
-/etc/default/stellar-captive-core /etc/default/stellar-soroban-rpc

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.links
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.links
@@ -1,0 +1,2 @@
+/etc/stellar/stellar-core_captive-futurenet.cfg /etc/stellar/soroban-rpc/etc/stellar-captive-core.cfg
+/etc/default/stellar-captive-core /etc/default/stellar-soroban-rpc

--- a/stellar-soroban-rpc/debian/stellar-soroban-rpc.links
+++ b/stellar-soroban-rpc/debian/stellar-soroban-rpc.links
@@ -1,1 +1,1 @@
-/etc/stellar/stellar-core_captive-futurenet.cfg /etc/stellar/soroban-rpc/etc/stellar-captive-core.cfg
+/etc/stellar/stellar-core_captive-futurenet.cfg /etc/stellar/soroban-rpc/stellar-captive-core.cfg

--- a/stellar-soroban-rpc/stellar-core_captive-futurenet.cfg
+++ b/stellar-soroban-rpc/stellar-core_captive-futurenet.cfg
@@ -29,5 +29,5 @@ NAME="sdf_futurenet_1"
 HOME_DOMAIN="futurenet.stellar.org"
 PUBLIC_KEY="GBRIF2N52GVN3EXBBICD5F4L5VUFXK6S6VOUCF6T2DWPLOLGWEPPYZTF"
 ADDRESS="core-live-futurenet.stellar.org:11625"
-HISTORY="curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+HISTORY="curl -sf https://history-futurenet.stellar.org/{0} -o {1}"
 

--- a/stellar-soroban-rpc/stellar-core_captive-futurenet.cfg
+++ b/stellar-soroban-rpc/stellar-core_captive-futurenet.cfg
@@ -1,0 +1,33 @@
+# This is a sample configuration from the stellar-captive-core package.
+# Please note that only HOME_DOMAINS and VALIDATORS tables are required.
+
+# IMPORTANT
+# You need to change domains and validators below to fit your needs
+
+# captive core config for futurenet
+NETWORK_PASSPHRASE="Test SDF Future Network ; October 2022"
+# disable the web service port, not used
+HTTP_PORT=0
+PUBLIC_HTTP_PORT=false
+# To avoid conflicts with the core instance
+PEER_PORT=11726
+DATABASE="sqlite3:///var/lib/stellar/soroban-rpc/captive-core/stellar-rpc.db"
+
+EXPERIMENTAL_BUCKETLIST_DB=true
+EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT=12
+ENABLE_SOROBAN_DIAGNOSTIC_EVENTS=false
+
+FAILURE_SAFETY=0
+UNSAFE_QUORUM=true
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="futurenet.stellar.org"
+QUALITY="MEDIUM"
+
+[[VALIDATORS]]
+NAME="sdf_futurenet_1"
+HOME_DOMAIN="futurenet.stellar.org"
+PUBLIC_KEY="GBRIF2N52GVN3EXBBICD5F4L5VUFXK6S6VOUCF6T2DWPLOLGWEPPYZTF"
+ADDRESS="core-live-futurenet.stellar.org:11625"
+HISTORY="curl -sf http://history-futurenet.stellar.org/{0} -o {1}"
+


### PR DESCRIPTION
Fixes #194 
If we end up doing this we need to update the `pipelines` repo to `sed` the `_CORE_VERSION_` into place.
  - See: https://github.com/stellar/pipelines/pull/560