### PR TITLE
Correct context to reflect recent sed change from / to @ in useLocalPackageVersion.diff

### DIFF
--- a/stellar-core/debian/patches/useLocalPackageVersion.diff
+++ b/stellar-core/debian/patches/useLocalPackageVersion.diff
@@ -8,6 +8,6 @@
 -		&& git describe --always --dirty --tags 2>/dev/null \
 -		|| echo "$(PACKAGE) $(VERSION)"); \
 +	@vers=$$(echo "${LOCAL_PACKAGE} ${LOCAL_VERSION} (${GIT_COMMIT})"); \
- 		sed -e "s/%%VERSION%%/$$vers/" \
+ 		sed -e "s@%%VERSION%%@$$vers@" \
  			< "$(srcdir)/main/StellarCoreVersion.cpp.in" > $@~
  	@if cmp -s $@~ $@; then rm -f $@~; else \


### PR DESCRIPTION
In stellar-core PR https://github.com/stellar/stellar-core/pull/3751 the `sed` command (embedded in `Makefile.am`) used to splice version strings into core was changed from using `/` to using `@` so that the version string can contain a `/` (as it does when it's a github PR or other complex git ref).

The line of code this `sed` command occurs on is unfortunately captured over here as well, as a context line for a diff that we apply when packaging stellar-core: we slightly modify the `Makefile.am` to use the package and jenkins build version we're building rather than the git-derived local build version number. Since the `sed` line changed, this patch no longer applies, and the package build fails.

This change just updates the `sed` command captured in the context of that diff to reflect the change made on core. It's not the prettiest way to fix the problem but hopefully it will unblock the build.