### PR TITLE
Improve stellar-core systemd unit file

### DIFF
--- a/stellar-core/debian/stellar-core.service
+++ b/stellar-core/debian/stellar-core.service
@@ -2,6 +2,8 @@
 Description=SDF - stellar-core
 Before=multi-user.target
 #PartOf=stellar.service
+StartLimitBurst=5
+StartLimitIntervalSec=30s
 
 [Service]
 User=stellar
@@ -12,6 +14,7 @@ KillMode=process
 Restart=on-failure
 RestartPreventExitStatus=255
 Type=simple
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently if core fails to start systemd will retry 5 times with 100ms pause between attempts. This is too aggressive in some situations. For example if postgres was upgraded right before core then core may be unable to start.

Updated unit file adds 5s pause between attempts, extends maximum duration of restart attempts to 30s and explicily sets restart limit of 5 (no change).