### PR TITLE
Replace SatoshiPay with OBSRVR in pubnet full validator example

### DIFF
--- a/docs/examples/pubnet-validator-full/stellar-core.cfg
+++ b/docs/examples/pubnet-validator-full/stellar-core.cfg
@@ -50,7 +50,7 @@ HOME_DOMAIN="www.franklintempleton.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
-HOME_DOMAIN="satoshipay.io"
+HOME_DOMAIN="stellar.withobsrvr.com"
 QUALITY="HIGH"
 
 [[HOME_DOMAINS]]
@@ -129,25 +129,25 @@ HISTORY="curl -sf https://stellar-history-usw.franklintempleton.com/azuswshf401/
 HOME_DOMAIN="www.franklintempleton.com"
 
 [[VALIDATORS]]
-NAME="SatoshiPay Frankfurt"
-PUBLIC_KEY="GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE"
-ADDRESS="stellar-de-fra.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-de-fra.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay.io"
+NAME="OBSRVR Validator 1"
+PUBLIC_KEY="GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS"
+ADDRESS="core-live-1.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-1.nodeswithobsrvr.co/obsrvr-core-1/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
 
 [[VALIDATORS]]
-NAME="SatoshiPay Singapore"
-PUBLIC_KEY="GBJQUIXUO4XSNPAUT6ODLZUJRV2NPXYASKUBY4G5MYP3M47PCVI55MNT"
-ADDRESS="stellar-sg-sin.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-sg-sin.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay.io"
+NAME="OBSRVR Validator 2"
+PUBLIC_KEY="GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF"
+ADDRESS="core-live-2.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-2.nodeswithobsrvr.co/obsrvr-core-2/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
 
 [[VALIDATORS]]
-NAME="SatoshiPay Iowa"
-PUBLIC_KEY="GAK6Z5UVGUVSEK6PEOCAYJISTT5EJBB34PN3NOLEQG2SUKXRVV2F6HZY"
-ADDRESS="stellar-us-iowa.satoshipay.io:11625"
-HISTORY="curl -sf https://stellar-history-us-iowa.satoshipay.io/{0} -o {1}"
-HOME_DOMAIN="satoshipay.io"
+NAME="OBSRVR Validator 3"
+PUBLIC_KEY="GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB"
+ADDRESS="core-live-3.nodeswithobsrvr.co:11625"
+HISTORY="curl -sf https://history-3.nodeswithobsrvr.co/obsrvr-core-3/{0} -o {1}"
+HOME_DOMAIN="stellar.withobsrvr.com"
 
 [[VALIDATORS]]
 NAME = "Creit Alpha"


### PR DESCRIPTION
## What

Updates `docs/examples/pubnet-validator-full/stellar-core.cfg` to:

1. **Remove SatoshiPay** — the `satoshipay.io` home domain and its three validators (Frankfurt, Singapore, Iowa). SatoshiPay no longer operates public Stellar validators.
2. **Add OBSRVR** — the `stellar.withobsrvr.com` home domain and its three HIGH-quality full validators.

## OBSRVR validators added

| Name | Public key | Address | History archive |
|------|------------|---------|-----------------|
| OBSRVR Validator 1 | `GDRCZ4IPJR7V3HK4GR45CRTE72SDAOZUF2TDBQ5E5IGWC4KM5TSKU2LS` | `core-live-1.nodeswithobsrvr.co:11625` | `https://history-1.nodeswithobsrvr.co/obsrvr-core-1/` |
| OBSRVR Validator 2 | `GA2PU4UGMLSFUXGZATHPTDXXX7FOHBAQC57RSJCQUN72WFKTD6CEPQSF` | `core-live-2.nodeswithobsrvr.co:11625` | `https://history-2.nodeswithobsrvr.co/obsrvr-core-2/` |
| OBSRVR Validator 3 | `GACM6GIRMLXBBZIYJXBDTAEYZ2GJP3JJP5G5K4WDPBS6QFHPJNK6S2FB` | `core-live-3.nodeswithobsrvr.co:11625` | `https://history-3.nodeswithobsrvr.co/obsrvr-core-3/` |

## Source & verification

Node details (public keys, peer addresses, history URLs, home domain) sourced from [OBSRVR Radar](https://radar.withobsrvr.com) — see the [API docs](https://radar.withobsrvr.com/api/docs/). All three are reported as HIGH-quality full validators.

Each history archive was verified reachable — `GET .well-known/stellar-history.json` returns `200` for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)