### PR TITLE
Add Figure (YLDS), MoneyGram, and Range to pubnet validator example

### DIFF
--- a/docs/examples/pubnet-validator-full/stellar-core.cfg
+++ b/docs/examples/pubnet-validator-full/stellar-core.cfg
@@ -270,16 +270,19 @@ HOME_DOMAIN="moneygram.com"
 NAME="Range 1"
 PUBLIC_KEY="GA3NWOLWTIFBYUNDXNE3E7TZSYNQQCKLHZQZFV7KSK7XPDU2ESVGISKT"
 ADDRESS="84.32.64.49:11625"
+HISTORY="curl -sf https://history-1.stellar.range.org/{0} -o {1}"
 HOME_DOMAIN="stellar.validator.range.org"
 
 [[VALIDATORS]]
 NAME="Range 2"
 PUBLIC_KEY="GA5MQHKWKZF24MWTDXVJE6UYI5QVBYFIVUP24RWYAXQIT5AIMZ6TMUXC"
 ADDRESS="185.191.116.157:11625"
+HISTORY="curl -sf https://history-2.stellar.range.org/{0} -o {1}"
 HOME_DOMAIN="stellar.validator.range.org"
 
 [[VALIDATORS]]
 NAME="Range 3"
 PUBLIC_KEY="GCSXADVBPPKIDUW6FDJZR25IX4ZA7B7YH63U2AZK7LVHSMLFGCKDBTBI"
 ADDRESS="84.32.103.134:11625"
+HISTORY="curl -sf https://history-3.stellar.range.org/{0} -o {1}"
 HOME_DOMAIN="stellar.validator.range.org"

--- a/docs/examples/pubnet-validator-full/stellar-core.cfg
+++ b/docs/examples/pubnet-validator-full/stellar-core.cfg
@@ -65,6 +65,18 @@ QUALITY="HIGH"
 HOME_DOMAIN="stellar.blockdaemon.com"
 QUALITY="HIGH"
 
+[[HOME_DOMAINS]]
+HOME_DOMAIN="www.ylds.com"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="moneygram.com"
+QUALITY="HIGH"
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="stellar.validator.range.org"
+QUALITY="HIGH"
+
 [[VALIDATORS]]
 NAME="Boötes"
 PUBLIC_KEY="GCVJ4Z6TI6Z2SOGENSPXDQ2U4RKH3CNQKYUHNSSPYFPNWTLGS6EBH7I2"
@@ -211,3 +223,63 @@ PUBLIC_KEY="GAAV2GCVFLNN522ORUYFV33E76VPC22E72S75AQ6MBR5V45Z5DWVPWEU"
 ADDRESS="stellar-full-validator1.bdnodes.net:11625"
 HISTORY="curl -sf https://stellar-full-history1.bdnodes.net/{0} -o {1}"
 HOME_DOMAIN="stellar.blockdaemon.com"
+
+[[VALIDATORS]]
+NAME="YLDS Central"
+PUBLIC_KEY="GDSQ7BEI6NCDHDOPABHTFDDOXCUVN4Z5MGYYMBVYW3G5CNHQMQM2RPE5"
+ADDRESS="stellar-central.ylds.com:11625"
+HISTORY="curl -sf http://stellar-history.ylds.com/validator-us-central1-0/{0} -o {1}"
+HOME_DOMAIN="www.ylds.com"
+
+[[VALIDATORS]]
+NAME="YLDS East"
+PUBLIC_KEY="GB3BMQGHJDJ3H2HJATFSXMHMZVXXJT5QCOQDGO3JHH6EISLY3J44CMZK"
+ADDRESS="stellar-east.ylds.com:11625"
+HISTORY="curl -sf http://stellar-history.ylds.com/validator-us-east1-0/{0} -o {1}"
+HOME_DOMAIN="www.ylds.com"
+
+[[VALIDATORS]]
+NAME="YLDS West"
+PUBLIC_KEY="GBRMVYACW2T5MVFKZPAJF6PE5KLLRMLYPSPTRJ4SHAIDRSVXYMQNGWB4"
+ADDRESS="stellar-west.ylds.com:11625"
+HISTORY="curl -sf http://stellar-history.ylds.com/validator-us-west1-0/{0} -o {1}"
+HOME_DOMAIN="www.ylds.com"
+
+[[VALIDATORS]]
+NAME="MoneyGram Validator 1"
+PUBLIC_KEY="GAVEOQE4O53I7OLY43HIUVKLLMALHSCNPVBKXB46FBDVRTDXRBIPHTFP"
+ADDRESS="v1-stellar.moneygram.com:11625"
+HISTORY="curl -sf https://stellar-history.moneygram.com/v1/{0} -o {1}"
+HOME_DOMAIN="moneygram.com"
+
+[[VALIDATORS]]
+NAME="MoneyGram Validator 2"
+PUBLIC_KEY="GBPBEOYMDXXBP2IG7LDM64YMLVTU3G567HWOKMMDOOCFFDFKAFVRDYM7"
+ADDRESS="v2-stellar.moneygram.com:11625"
+HISTORY="curl -sf https://stellar-history.moneygram.com/v2/{0} -o {1}"
+HOME_DOMAIN="moneygram.com"
+
+[[VALIDATORS]]
+NAME="MoneyGram Validator 3"
+PUBLIC_KEY="GAW3OEQRVXR3XFVLTUPZMLDQHKUSXECDCJYCR3MEAATC2QJ2ELLPXORD"
+ADDRESS="v3-stellar.moneygram.com:11625"
+HISTORY="curl -sf https://stellar-history.moneygram.com/v3/{0} -o {1}"
+HOME_DOMAIN="moneygram.com"
+
+[[VALIDATORS]]
+NAME="Range 1"
+PUBLIC_KEY="GA3NWOLWTIFBYUNDXNE3E7TZSYNQQCKLHZQZFV7KSK7XPDU2ESVGISKT"
+ADDRESS="84.32.64.49:11625"
+HOME_DOMAIN="stellar.validator.range.org"
+
+[[VALIDATORS]]
+NAME="Range 2"
+PUBLIC_KEY="GA5MQHKWKZF24MWTDXVJE6UYI5QVBYFIVUP24RWYAXQIT5AIMZ6TMUXC"
+ADDRESS="185.191.116.157:11625"
+HOME_DOMAIN="stellar.validator.range.org"
+
+[[VALIDATORS]]
+NAME="Range 3"
+PUBLIC_KEY="GCSXADVBPPKIDUW6FDJZR25IX4ZA7B7YH63U2AZK7LVHSMLFGCKDBTBI"
+ADDRESS="84.32.103.134:11625"
+HOME_DOMAIN="stellar.validator.range.org"

--- a/docs/examples/pubnet-validator-full/stellar-core.cfg
+++ b/docs/examples/pubnet-validator-full/stellar-core.cfg
@@ -269,20 +269,20 @@ HOME_DOMAIN="moneygram.com"
 [[VALIDATORS]]
 NAME="Range 1"
 PUBLIC_KEY="GA3NWOLWTIFBYUNDXNE3E7TZSYNQQCKLHZQZFV7KSK7XPDU2ESVGISKT"
-ADDRESS="84.32.64.49:11625"
+ADDRESS="core-1.stellar.range.org:11625"
 HISTORY="curl -sf https://history-1.stellar.range.org/{0} -o {1}"
 HOME_DOMAIN="stellar.validator.range.org"
 
 [[VALIDATORS]]
 NAME="Range 2"
 PUBLIC_KEY="GA5MQHKWKZF24MWTDXVJE6UYI5QVBYFIVUP24RWYAXQIT5AIMZ6TMUXC"
-ADDRESS="185.191.116.157:11625"
+ADDRESS="core-2.stellar.range.org:11625"
 HISTORY="curl -sf https://history-2.stellar.range.org/{0} -o {1}"
 HOME_DOMAIN="stellar.validator.range.org"
 
 [[VALIDATORS]]
 NAME="Range 3"
 PUBLIC_KEY="GCSXADVBPPKIDUW6FDJZR25IX4ZA7B7YH63U2AZK7LVHSMLFGCKDBTBI"
-ADDRESS="84.32.103.134:11625"
+ADDRESS="core-3.stellar.range.org:11625"
 HISTORY="curl -sf https://history-3.stellar.range.org/{0} -o {1}"
 HOME_DOMAIN="stellar.validator.range.org"


### PR DESCRIPTION
## What

Adds three HIGH-quality organizations to the example pubnet full validator quorum set in `docs/examples/pubnet-validator-full/stellar-core.cfg`:

| Organization | `HOME_DOMAIN` | Validators |
| --- | --- | --- |
| Figure (YLDS) | `www.ylds.com` | YLDS Central / East / West |
| MoneyGram | `moneygram.com` | MoneyGram Validator 1 / 2 / 3 |
| Range | `stellar.validator.range.org` | Range 1 / 2 / 3 |

This takes the example quorum set from 7 to 10 organizations (21 → 30 validators, 3 per org). All 30 validators have a history archive.

## Where the data came from

Validators were identified via [Radar](https://radar.withobsrvr.com/), then every public key, address, and history archive URL was cross-checked against each organization's published `stellar.toml`:

- https://www.ylds.com/.well-known/stellar.toml
- https://moneygram.com/.well-known/stellar.toml
- https://stellar.validator.range.org/.well-known/stellar.toml

All 9 public keys, hosts, and archive URLs match their `stellar.toml` entries exactly.

## Note for reviewers

Formatting follows the file's dominant `KEY="value"` style (no spaces around `=`), and field order within each `[[VALIDATORS]]` block matches the rest of the file (`NAME`, `PUBLIC_KEY`, `ADDRESS`, `HISTORY`, `HOME_DOMAIN`).

## Verification

Parsed the resulting file and checked:

- No duplicate `HOME_DOMAIN`, `NAME`, `PUBLIC_KEY`, `ADDRESS`, or `HISTORY` values
- Every validator's `HOME_DOMAIN` has a matching `[[HOME_DOMAINS]]` entry, and every `[[HOME_DOMAINS]]` entry has validators
- All 30 public keys are valid Stellar strkeys (correct version byte, length, and CRC16 checksum)
- Every organization has `QUALITY="HIGH"` and exactly 3 validators
- Every validator has a well-formed `HISTORY` command template containing both `{0}` and `{1}`

The nine newly added archives were fetched using the exact substituted command stellar-core would run, and all nine returned a valid `stellar-history.json` carrying the pubnet passphrase.
